### PR TITLE
Distinguish steps and calories vars in different datasets

### DIFF
--- a/R/summarize_pipeline.R
+++ b/R/summarize_pipeline.R
@@ -77,6 +77,11 @@ summarize_pipeline <- function(ontologyFileID,
       return(df)
     })
   
+  df_list$fitbitactivitylogs <- 
+    df_list$fitbitactivitylogs %>% 
+    dplyr::rename(activitylogs_steps = steps,
+                  activitylogs_calories = calories)
+  
   concept_replacements_reversed <- vec_reverse(concept_replacements)
   cat("vec_reverse() completed.\n")
   


### PR DESCRIPTION
## Major Changes

1. Rename steps and calories variables in fitbitactivitylogs dataset to avoid combining with steps and calories variables in fitbitdailydata dataset