### PR TITLE
Patch release 1.3.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: recoverSummarizeR
 Title: Functions for handling and summarizing data primarily for RECOVER
-Version: 1.3.1
+Version: 1.3.2
 Authors@R: c(
     person("Pranav", "Anbarasu", , "pranavanba@gmail.com", role = c("aut", "cre")),
     person("Sage Bionetworks", role = "cph")

--- a/R/syn_parquet_dataset_to_dflist.R
+++ b/R/syn_parquet_dataset_to_dflist.R
@@ -52,7 +52,8 @@ syn_parquet_dataset_to_dflist <- function(synDirID, method="synapse", s3bucket=N
                'AWS_SESSION_TOKEN'=token$sessionToken)
     
     unlink(downloadLocation, recursive = T, force = T)
-    sync_cmd <- glue::glue('aws s3 sync {base_s3_uri} {downloadLocation} --exclude "*owner.txt*" --exclude "*archive*"')
+    inclusions <- paste0("--include \"*",dataset_name_filter,"*\"", collapse = " ")
+    sync_cmd <- glue::glue('aws s3 sync {base_s3_uri} {downloadLocation} --exclude "*" {inclusions}')
     system(sync_cmd)
     
   } else {
@@ -96,11 +97,6 @@ syn_parquet_dataset_to_dflist <- function(synDirID, method="synapse", s3bucket=N
     file_paths %>% 
     {paste(basename(.))} %>%
     {gsub("\\.(parquet|tsv|ndjson)$|(dataset_|-.*\\.snappy| )", "", .)}
-  
-  if (!is.null(dataset_name_filter)) {
-    pattern <- paste(dataset_name_filter, collapse="|")
-    df_list <- df_list[grepl(tolower(pattern), tolower(names(df_list))) & !grepl("manifest", tolower(names(df_list)))]
-  }
   
   return(df_list)
 }


### PR DESCRIPTION
## Major Changes

1. When using `sts` method for `syn_parquet_dataset_to_dflist()`, sync only the folders whose names match the patterns in the `dataset_name_filter` param

## Minor Changes

1. Increment version number to `1.3.2` from `1.3.1`
